### PR TITLE
27.1-2 error

### DIFF
--- a/docs/Chap27/27.1.md
+++ b/docs/Chap27/27.1.md
@@ -9,8 +9,8 @@ There will be no change in the asymptotic work, span, or parallelism of $\text{P
 > Draw the computation dag that results from executing $\text{P-FIB}(5)$. Assuming that each strand in the computation takes unit time, what are the work, span, and parallelism of the computation? Show how to schedule the dag on 3 processors using greedy scheduling by labeling each strand with the time step in which it is executed.
 
 - Work: $T_1 = 29$.
-- Span: $T_\infty = 9$.
-- Parallelism: $T_1 / T_\infty \approx 3.2$.
+- Span: $T_\infty = 10$.
+- Parallelism: $T_1 / T_\infty \approx 2.9$.
 
 ## 27.1-3
 


### PR DESCRIPTION
span is 10, not 9 because there are 10 strands in the critical path albeit 9 edges. span corresponds to the # of strands not edges.