### PR TITLE
Remove wrong negation from tree-min and tree-max

### DIFF
--- a/docs/Chap12/12.2.md
+++ b/docs/Chap12/12.2.md
@@ -21,14 +21,14 @@
 
 ```cpp
 TREE-MINIMUM(x)
-    if !x.left
+    if x.left
         return TREE-MINIMUM(x.left)
     return x
 ```
 
 ```cpp
 TREE-MAXIMUM(x)
-    if !x.right
+    if x.right
         return TREE-MAXIMUM(x.right)
     return x
 ```


### PR DESCRIPTION
We should traverse the child if it exists and not the opposite.