### PR TITLE
Fix some typos

### DIFF
--- a/docs/Chap26/26.1.md
+++ b/docs/Chap26/26.1.md
@@ -8,7 +8,7 @@ $$
 f'(y, z) =
 \begin{cases}
 f(y, z) & \text{if $(y, z) \ne (u, x)$ and $(y, z) \ne (x, v)$}, \\\\
-f(u, z) & \text{if $(y, z) =   (u, x)$ or  $(y, z) =   (x, v)$}.
+f(u, v) & \text{if $(y, z) =   (u, x)$ or  $(y, z) =   (x, v)$}.
 \end{cases}
 $$
 

--- a/docs/Chap26/26.1.md
+++ b/docs/Chap26/26.1.md
@@ -19,8 +19,8 @@ We first prove that $f'$ satisfies the required properties of a flow. It is obvi
 To show that edges $(u, x)$ and $(x, v)$ obey the capacity constraint, we have
 
 \begin{align}
-f(u, x) = f(u, v) & \le c(u, v) = c(u, x), \\\\
-f(x, v) = f(u, v) & \le c(u, v) = c(x, v). 
+f'(u, x) = f(u, v) & \le c(u, v) = c(u, x), \\\\
+f'(x, v) = f(u, v) & \le c(u, v) = c(x, v). 
 \end{align}
 
 We now prove flow conservation for $u$. Assuming that $u \ne \\{s, t\\}$, we have


### PR DESCRIPTION
The definition of flow f' in G' should be exactly the same as f in G;
except for two edges (u, x), and (x, v) which is equal to (u, v). On the
other hand, f(u, x) and f(x, v) are undefined, because G has no vertex x
which is augmented to G to construct G'.