### PR TITLE
Update 19-3.md

### DIFF
--- a/docs/Chap19/Problems/19-3.md
+++ b/docs/Chap19/Problems/19-3.md
@@ -4,7 +4,7 @@
 >
 > **b.** Give an efficient implementation of $\text{FIB-HEAP-PRUNE}(H, r)$, which deletes $q = \min(r, H.n)$ nodes from $H$. You may choose any $q$ nodes to delete. Analyze the amortized running time of your implementation. ($\textit{Hint:}$ You may need to modify the data structure and potential function.)
 
-**a.** If $k < x.key$ just run the decrease key procedure. If $k > x.key$, delete the current value $x$ and insert $x$ again with a new key. Both of these cases only need $O(\lg(n))$ amortized time to run.
+**a.** If $k < x.key$ just run the decrease key procedure. If $k > x.key$, delete the current value $x$ and insert $x$ again with a new key. For the first case, the amortized time is $O(1)$, and for the last case the amortized time is $O(lg(n))$.
 
 **b.** Suppose that we also had an additional cost to the potential function that was proportional to the size of the structure. This would only increase when we do an insertion, and then only by a constant amount, so there aren't any worries concerning this increased potential function raising the amortized cost of any operations. Once we've made this modification, to the potential function, we also modify the heap itself by having a doubly linked list along all of the leaf nodes in the heap. 
 

--- a/docs/Chap19/Problems/19-3.md
+++ b/docs/Chap19/Problems/19-3.md
@@ -4,7 +4,7 @@
 >
 > **b.** Give an efficient implementation of $\text{FIB-HEAP-PRUNE}(H, r)$, which deletes $q = \min(r, H.n)$ nodes from $H$. You may choose any $q$ nodes to delete. Analyze the amortized running time of your implementation. ($\textit{Hint:}$ You may need to modify the data structure and potential function.)
 
-**a.** If $k < x.key$ just run the decrease key procedure. If $k > x.key$, delete the current value $x$ and insert $x$ again with a new key. For the first case, the amortized time is $O(1)$, and for the last case the amortized time is $O(lg(n))$.
+**a.** If $k < x.key$ just run the decrease key procedure. If $k > x.key$, delete the current value $x$ and insert $x$ again with a new key. For the first case, the amortized time is $O(1)$, and for the last case the amortized time is $O(\lg n)$.
 
 **b.** Suppose that we also had an additional cost to the potential function that was proportional to the size of the structure. This would only increase when we do an insertion, and then only by a constant amount, so there aren't any worries concerning this increased potential function raising the amortized cost of any operations. Once we've made this modification, to the potential function, we also modify the heap itself by having a doubly linked list along all of the leaf nodes in the heap. 
 


### PR DESCRIPTION
If k < x.key we just call FIB-HEAP-DECREASE-KEY as described in CLRS page 519 3rd edition. This functions amortized cost is shown to be O(1)  CLRS page 520-522 3rd edition. Hope this helps :)