### PR TITLE
Update 4.5.md

### DIFF
--- a/docs/Chap04/4.5.md
+++ b/docs/Chap04/4.5.md
@@ -44,16 +44,16 @@ $$
 
 With $a = 4$, $b = 2$, we have $f(n) = n^2\lg n \ne O(n^{2 - \epsilon}) \ne \Omega(n^{2 + \epsilon})$, so we cannot apply the master method.
 
-We guess $T(n) \le cn^2\lg^2 n$,
+We guess $T(n) \le cn^2\lg^2 n$, subsituting $T(n/2) \le c(n/2)^2\lg^2 (n/2)$ into the recurrence yields
 
 $$
 \begin{aligned}
-T(n) & \le 4T(n / 2) + n^2\lg n \\\\
-     & =   4c(n / 2)^2\lg^2(n / 2) + n^2\lg n \\\\
+T(n) & = 4T(n / 2) + n^2\lg n \\\\
+     & \le 4c(n / 2)^2\lg^2(n / 2) + n^2\lg n \\\\
      & =   cn^2\lg(n / 2)\lg n - cn^2\lg(n / 2)\lg 2 + n^2\lg n \\\\
-     & =   cn^2\lg^2 n - cn^2\lg n\lg 2 - cn^2\lg(n / 2) + n^2\lg n \\\\
-     & =   cn^2\lg^2 n + (1 - c\lg 2)n^2\lg n - cn^2\lg(n / 2) & (c \ge 1/\lg 2) \\\\
-     & \le cn^2\lg^2 n - cn^2\lg(n / 2) \\\\
+     & =   cn^2\lg^2 n - cn^2\lg n\lg 2 - cn^2\lg(n / 2)\lg 2 + n^2\lg n \\\\
+     & =   cn^2\lg^2 n + (1 - c\lg 2)n^2\lg n - cn^2\lg(n / 2)\lg 2 & (c \ge 1/\lg 2) \\\\
+     & \le cn^2\lg^2 n - cn^2\lg(n / 2)\lg 2 \\\\
      & \le cn^2\lg^2 n.
 \end{aligned}
 $$

--- a/docs/Chap04/4.5.md
+++ b/docs/Chap04/4.5.md
@@ -48,7 +48,7 @@ We guess $T(n) \le cn^2\lg^2 n$, subsituting $T(n/2) \le c(n/2)^2\lg^2 (n/2)$ in
 
 $$
 \begin{aligned}
-T(n) & = 4T(n / 2) + n^2\lg n \\\\
+T(n) & =   4T(n / 2) + n^2\lg n \\\\
      & \le 4c(n / 2)^2\lg^2(n / 2) + n^2\lg n \\\\
      & =   cn^2\lg(n / 2)\lg n - cn^2\lg(n / 2)\lg 2 + n^2\lg n \\\\
      & =   cn^2\lg^2 n - cn^2\lg n\lg 2 - cn^2\lg(n / 2)\lg 2 + n^2\lg n \\\\

--- a/docs/Chap04/4.5.md
+++ b/docs/Chap04/4.5.md
@@ -26,7 +26,7 @@ Strassen's algorithm has running time of $\Theta(n^{\lg 7})$.
 
 The largest integer $a$ such that $\log_4 a < \lg 7$ is $a = 48$.
 
-## 4.5.3
+## 4.5-3
 
 > Use the master method to show that the solution to the binary-search recurrence $T(n) = T(n / 2) + \Theta(1)$ is $T(n) = \Theta(\lg n)$. (See exercise 2.3-5 for a description of binary search.)
 
@@ -42,7 +42,7 @@ $$
 
 > Can the master method be applied to the recurrence $T(n) = 4T(n / 2) + n^2\lg n$? Why or why not? Give an asymptotic upper bound for this recurrence.
 
-With $a = 4$, $b = 2$, we have $f(n) = n^2\lg n \ne O(n^{2 - \epsilon}) \ne \Omega(n^{2 - \epsilon})$, so we cannot apply the master method.
+With $a = 4$, $b = 2$, we have $f(n) = n^2\lg n \ne O(n^{2 - \epsilon}) \ne \Omega(n^{2 + \epsilon})$, so we cannot apply the master method.
 
 We guess $T(n) \le cn^2\lg^2 n$,
 
@@ -52,7 +52,7 @@ T(n) & \le 4T(n / 2) + n^2\lg n \\\\
      & =   4c(n / 2)^2\lg^2(n / 2) + n^2\lg n \\\\
      & =   cn^2\lg(n / 2)\lg n - cn^2\lg(n / 2)\lg 2 + n^2\lg n \\\\
      & =   cn^2\lg^2 n - cn^2\lg n\lg 2 - cn^2\lg(n / 2) + n^2\lg n \\\\
-     & =   cn^2\lg^2 n + (1 - c)n^2\lg n - cn^2\lg(n / 2) & (c > 1) \\\\
+     & =   cn^2\lg^2 n + (1 - c\lg 2)n^2\lg n - cn^2\lg(n / 2) & (c \ge 1/\lg 2) \\\\
      & \le cn^2\lg^2 n - cn^2\lg(n / 2) \\\\
      & \le cn^2\lg^2 n.
 \end{aligned}


### PR DESCRIPTION
Fixed a typo of "4.5-3".
Added the missing constant lg 2 of a term in the solution of 4.5-4.