### PR TITLE
Update 11.1.md

### DIFF
--- a/docs/Chap11/11.1.md
+++ b/docs/Chap11/11.1.md
@@ -61,12 +61,12 @@ Assuming that fetching an element should return the satellite data of all the st
 
 > We wish to implement a dictionary by using direct addressing on a _huge_ array. At the start, the array entries may contain garbage, and initializing the entire array is impractical because of its size. Describe a scheme for implementing a direct-address dictionary on a huge array. Each stored object should use $O(1)$ space; the operations $\text{SEARCH}$, $\text{INSERT}$, and $\text{DELETE}$ should take $O(1)$ time each; and initializing the data structure should take $O(1)$ time. ($\textit{Hint:}$ Use an additional array, treated somewhat like a stack whose size is the number of keys actually stored in the dictionary, to help determine whether a given entry in the huge array is valid or not.)
 
-The additional data structure will be a doubly linked list $S$ which behave in many ways like a stack.
+The additional data structure will be a stack $S$.
 
 Initially, set $S$ to be empty, and do nothing to initialize the huge array. Each object stored in the huge array will have two parts: the key value, and a pointer to an element of $S$, which contains a pointer back to the object in the huge array.
 
-- To insert $x$, add an element $y$ to the stack which contains a pointer to position $x$ in the huge array. Update position $A[x]$ in the huge array $A$ to contain a pointer to $y$ in $S$.
+- To insert $x$, push an element $y$ to the stack which contains a pointer to position $x$ in the huge array. Update position $A[x]$ in the huge array $A$ to contain a pointer to $y$ in $S$.
 
 - To search for $x$, go to position $x$ of $A$ and go to the location stored there. If that location is an element of $S$ which contains a pointer to $A[x]$, then we know $x$ is in $A$. Otherwise, $x \notin A$.
 
-- To delete $x$, delete the element of $S$ which is pointed to by $A[x]$. Each of these takes $O(1)$ and there are at most as many elements in $S$ as there are valid elements in $A$.
+- To delete $x$, invalidate the element of $S$ which is pointed to by $A[x]$. Because there may be "holes" in $S$ now, we need to pop an item from $S$, move it to the position of the "hole", and update the pointer in $A$ accordingly. Each of these takes $O(1)$ time and there are at most as many elements in $S$ as there are valid elements in $A$.


### PR DESCRIPTION
The original solution involved doubly-linked lists, which was unnecessary (and didn't really "behave like a stack"). The correct / intended solution is to actually use a stack, laid out as a plain array. This PR updates the solution to the right way.