### PR TITLE
Update 25.2.md

### DIFF
--- a/docs/Chap25/25.2.md
+++ b/docs/Chap25/25.2.md
@@ -167,7 +167,7 @@ If we already have the $n^3$ values in $\phi_{ij}^{(k)}$ provided, then we can r
 > Give an $O(VE)$-time algorithm for computing the transitive closure of a directed
 > graph $G = (V, E)$.
 
-Create an $n$ by $n$ matrix $A$ filled with $0$'s. We are done if we can determine the vertices reachable from a particular vertex in $O(E)$ time, since we can just compute this for each $v \in V$. To do this, assign each edge weight $1$. Then we have $\delta(v, u) \le |E|$ for all $u \in V$. By Problem 24-4(a) we can compute $\delta(v, u)$ in $O(E)$ forall $u \in V$. If $\delta(v, u) < \infty$, set $A_{ij} = 1$. Otherwise, leave it as $0$.
+We can determine the vertices reachable from a particular vertex in $O(V + E)$ time using any basic graph searching algorithm. Thus we can compute the transitive closure in $O(VE + V^2)$ time by searching the graph with each vertex as the source. If $|V| = O(E)$, we're done as $VE$ is now the dominating term in the running time bound. If not, we preprocess the graph and mark all degree-$0$ vertices in $O(V + E)$ time. The rows representing these vertices in the transitive closure are all $0$s, which means that the algorithm remains correct if we ignore these vertices when searching. After preprocessing, $|V| = O(E)$ as $|E| \geq |V|/2$. Therefore searching can be done in $O(VE)$ time.
 
 ## 25.2-9
 


### PR DESCRIPTION
The original solution is wrong as problem 24-4 made the assumption that |E| >= |V| - 1 beforehand. The algorithm used in the original solution actually runs in O(WV + E) time, which, without the assumption above and assuming binary edge weights, has the same asymptotic time bound as BFS or DFS.