### PR TITLE
Update 15.3.md

### DIFF
--- a/docs/Chap15/15.3.md
+++ b/docs/Chap15/15.3.md
@@ -2,18 +2,13 @@
 
 > Which is a more efficient way to determine the optimal number of multiplications in a matrix-chain multiplication problem: enumerating all the ways of parenthesizing the product and computing the number of multiplications for each, or running $\text{RECURSIVE-MATRIX-CHAIN}$? Justify your answer.
 
-Running Recursive-Matrix-Chain is asymptotically more efficient than enumerating all the ways of parenthesizing the product and computing the number of multiplications for each.
+Running $\text{RECURSIVE-MATRIX-CHAIN}$ is asymptotically more efficient than enumerating all the ways of parenthesizing the product and computing the number of multiplications for each.
+
 Consider the treatment of subproblems by each approach:
-(i) For each possible place to split the matrix chain, the enumeration approach finds
-all ways to parenthesize the left half, finds all ways to parenthesize the right half,
-and looks at all possible combinations of the left half with the right half. The
-amount of work to look at each combination of left and right half subproblem
-results is thus the product of the number of ways to parenthesize the left half
-and the number of ways to parenthesize the right half.
-(ii) For each possible place to split the matrix chain, Recursive-Matrix-Chain
-finds the best way to parenthesize the left half, finds the best way to parenthesize
-the right half, and combines just those two results. Thus the amount of work to
-combine the left and right half subproblem results is O(1).
+
+1. For each possible place to split the matrix chain, the enumeration approach finds all ways to parenthesize the left half, finds all ways to parenthesize the right half, and looks at all possible combinations of the left half with the right half. The amount of work to look at each combination of left and right half subproblem results is thus the product of the number of ways to parenthesize the left half and the number of ways to parenthesize the right half.
+
+2. For each possible place to split the matrix chain, $\text{RECURSIVE-MATRIX-CHAIN}$ finds the best way to parenthesize the left half, finds the best way to parenthesize the right half, and combines just those two results. Thus the amount of work to combine the left and right half subproblem results is $O(1)$.
 
 ## 15.3-2
 

--- a/docs/Chap15/15.3.md
+++ b/docs/Chap15/15.3.md
@@ -2,7 +2,18 @@
 
 > Which is a more efficient way to determine the optimal number of multiplications in a matrix-chain multiplication problem: enumerating all the ways of parenthesizing the product and computing the number of multiplications for each, or running $\text{RECURSIVE-MATRIX-CHAIN}$? Justify your answer.
 
-The runtime of of enumerating is just $n \cdot P(n)$, while is we were running $\text{RECURSIVE-MATRIX-CHAIN}$, it would also have to run on all of the internal nodes of the subproblem tree. Also, the enumeration approach wouldn't have as much overhead.
+Running Recursive-Matrix-Chain is asymptotically more efficient than enumerating all the ways of parenthesizing the product and computing the number of multiplications for each.
+Consider the treatment of subproblems by each approach:
+(i) For each possible place to split the matrix chain, the enumeration approach finds
+all ways to parenthesize the left half, finds all ways to parenthesize the right half,
+and looks at all possible combinations of the left half with the right half. The
+amount of work to look at each combination of left and right half subproblem
+results is thus the product of the number of ways to parenthesize the left half
+and the number of ways to parenthesize the right half.
+(ii) For each possible place to split the matrix chain, Recursive-Matrix-Chain
+finds the best way to parenthesize the left half, finds the best way to parenthesize
+the right half, and combines just those two results. Thus the amount of work to
+combine the left and right half subproblem results is O(1).
 
 ## 15.3-2
 


### PR DESCRIPTION
Running Recursive-Matrix-Chain is asymptotically more efficient than enumerating all the ways of parenthesizing the product and computing the number of multiplications for each.
Consider the treatment of subproblems by each approach:
(i) For each possible place to split the matrix chain, the enumeration approach finds
all ways to parenthesize the left half, finds all ways to parenthesize the right half,
and looks at all possible combinations of the left half with the right half. The
amount of work to look at each combination of left and right half subproblem
results is thus the product of the number of ways to parenthesize the left half
and the number of ways to parenthesize the right half.
(ii) For each possible place to split the matrix chain, Recursive-Matrix-Chain
finds the best way to parenthesize the left half, finds the best way to parenthesize
the right half, and combines just those two results. Thus the amount of work to
combine the left and right half subproblem results is O(1).
Section 15.2 showed that the running time for enumeration is Ω( 4
n
n3/2 ). We will show
that the running time for Recursive-Matrix-Chain is O(n 3
n−1
).
To obtain an upper bound on the running time of Recursive-Matrix-Chain, we
shall use a similar approach as was used in Section 15.3 to obtain a lower bound.
First, we derive an upper bound recurrence and then use substitution to prove the
O bound. For the lower-bound recurrence, the book assumed that the execution
of lines 1-2 and 6-7 take at least unit time each. For the upper-bound recurrence,
we’ll assume those pairs of lines each take at most constant time c. This yields the
recurrence T(1) ≤ c and T(n) ≤ c +
nP−1
k=1
(T(k) + T(n − k) + c), for n > 1.
Due to the fact that for k = 1, 2, . . . , n − 1, each T(i) appears twice, the recurrence
can be rewritten as T(n) ≤ 2
nP−1
i=1
T(i) + cn.
We shall prove that T(n) = O(n 3
n−1
) by using the substitution method. (Note:
any upper bound on T(n) that is in o( 4
n
n3/2 ) will suffice. You might prefer to prove
one something simpler, such as T(n) = O(3.5
n
)). Specifically, we shall show that
T(n) ≤ cn 3
n−1
for all n ≥ 1. The basis is easy, since T(1) = c · 1 · 3
0 ≤ c. Inductively,
for n ≥ 2 we have:
T(n) ≤ 2
nX−1
i=1
T(i) + cn
≤ 2
nX−1
i=0
T(i) + cn
≤ 2
nX−1
i=0
ci3
i−1 + cn
2
= c(2
nX−1
i=0
i3
i−1 + n)
= c(2(n3
n−1
3 − 1
+
1 − 3
n
(3 − 1)2
) + n)
= cn3
n−1 + c(
1 − 3
n
2
+ n)
= cn3
n−1 +
c
2
(2n + 1 − 3
n
)
≤ cn3
n−1
for all c > 0, n ≥ 1
Note: the above substitution uses the fact that
nP−1
i=0
ixi−1 =
nxn−1
x−1 +
1−x
n
(x−1)2
. This can
be derived from Equation (A.5) by taking the derivative:
f(x) =
nX−1
i=0
x
i =
x
n − 1
x − 1
nX−1
i=0
ixi−1 = f
0
(x)
=
nxn−1
x − 1
+
1 − x
n
(x − 1)2
Running Recursive-Matrix-Chain takes O(n3
n−1
) time, and enumerating all
parenthesizations takes Ω( 4
n
n3/2 ) time, so Recursive-Matrix-Chain is more efficient than enumeration.