### PR TITLE
Update 2.1.md

### DIFF
--- a/docs/Chap02/2.1.md
+++ b/docs/Chap02/2.1.md
@@ -69,6 +69,6 @@ ADD-BINARY(A, B)
     for i = 1 to A.length
         C[i] = (A[i] + B[i] + carry) % 2  // remainder
         carry = (A[i] + B[i] + carry) / 2 // quotient
-    C[i] = carry
+    C[i + 1] = carry
     return C
 ```


### PR DESCRIPTION
The final carry over should be 'carried over' to the final element of array C, instead of incorrectly overwriting the second to last element.