### PR TITLE
Update 22.1.md: The algorithm of 22.1-4 given before is actually an $O(|V|^2 + |E|)$ time algorithm. Fix it.

### DIFF
--- a/docs/Chap22/22.1.md
+++ b/docs/Chap22/22.1.md
@@ -72,22 +72,23 @@
 
 > Given an adjacency-list representation of a multigraph $G = (V, E)$, describe an $O(V + E)$-time algorithm to compute the adjacency-list representation of the "equivalent" undirected graph $G' = (V, E')$, where $E'$ consists of the edges in $E$ with all multiple edges between two vertices replaced by a single edge and with all self-loops removed.
 
-Create a new adjacency-list $Adj'$ of size $|V|$ and an empty matrix $M$ of size $|V|^2$ first.
+Create a new adjacency-list $Adj'$ of size $|V|$ and a zero-initialized array $A$ of size $|V|$ first.
 For each vertex $u$ in the multigraph $G$, we iterably examine each vertex $v$ of $Adj[u]$.
 
-- If $M(u, v) == \emptyset$, mark $M(u, v)$ as $\text{true}$, then add $v$ to $Adj'[u]$.
-- If $M(u, v) == true$, do nothing.
+- If $v \ne u$ and $A[v] \ne u$, set $A[v]$ to $u$, then add $v$ to $Adj'[u]$.
+- Else, do nothing.
 
+Note that $A$ does not contain any element with value $u$ before each iteration of the inner for-loop. That's why we use $A[v] = u$ to mark the existence of an edge $(u, v)$ in the inner for-loop.
 Since we lookup in the adjacency-list $Adj$ for $|V| + |E|$ times, the time complexity is $O(|V| + |E|)$.
 
 ```cpp
 EQUIVALENT-UNDIRECTED-GRAPH
     let Adj'[1..|V|] be a new adjacency list
-    let M be |V| × |V|
+    let A be a 0-initialized array of size |V|
     for each vertex u ∈ G.V
         for each v ∈ Adj[u]
-            if M[u, v] == Ø && u != v
-                M[u, v] = true
+            if v != u && A[v] != u
+                A[v] = u
                 INSERT(Adj'[u], v)
 ```
 


### PR DESCRIPTION
The algorithm of 22.1-4 given before is actually an $O(|V|^2 + |E|)$ time algorithm since it's necessary to use $O(V^2)$ time to initialize the matrix $M$ of size $|V|^2$.
In the algorithm given in this pull request, we use an 0-initialized array $A$ of size $|V|$ to mark the existence of the edges in $Adj[u]$.
In the outer for-loop, we iterate $u$ from $1$ to $|V|$. We can assume that $A$ can contain elements with value from $0$ to $u-1$ before we go into the inner for-loop. 
And in the inner for-loop, we examine each vertex $v$ of $Adj[u]$. If $v \ne u$ and $A[v] \ne u$, we set $A[v]$ to $u$ to mark the existence of an edge $(u, v)$ and insert this edge into $Adj'[u]$.