### PR TITLE
Possible correction to Problem 19-1 c

### DIFF
--- a/docs/Chap19/Problems/19-1.md
+++ b/docs/Chap19/Problems/19-1.md
@@ -24,7 +24,7 @@
 
 **b.** Line 7 takes actual time bounded by $x.degree$ since updating each of the children of $x$ only takes constant time. So, if $c$ is the number of cascading cuts that are done, the actual cost is $O(c + x.degree)$.
 
-**c.** We examine the number of trees in the root list $t(H)$ and the number of marked nodes $m(H)$ of the resulting Fibonacci heap $H'$ to upper-bound its potential. The number of trees $t(H)$ increases by the number of children $x$ had ($=x.degree), due to line 7 of $\text{PISANO-DELETE(H, x)}$. The number of marked nodes in $H'$ is calculated as follows. The first $c - 1$ recursive calls out of the $c$ calls to $CASCADING-CUT$ unmarks a marked node (line 4 of $CUT$ invoked by line 5 of $CASCADING-CUT$). The final $c$th call to $CASCADING-CUT$ marks an unmarked node (line 4 of $CASCADING-CUT$), and therefore, the total change in marked nodes is $-(c - 1) + 1 = -c + 2$. Therefore, the potential of H' is
+**c.** We examine the number of trees in the root list $t(H)$ and the number of marked nodes $m(H)$ of the resulting Fibonacci heap $H'$ to upper-bound its potential. The number of trees $t(H)$ increases by the number of children $x$ had ($=x.degree$), due to line 7 of $\text{PISANO-DELETE}(H, x)$. The number of marked nodes in $H'$ is calculated as follows. The first $c - 1$ recursive calls out of the $c$ calls to $\text{CASCADING-CUT}$ unmarks a marked node (line 4 of $\text{CUT}$ invoked by line 5 of $\text{CASCADING-CUT}$). The final $c$th call to $\text{CASCADING-CUT}$ marks an unmarked node (line 4 of $\text{CASCADING-CUT}$), and therefore, the total change in marked nodes is $-(c - 1) + 1 = -c + 2$. Therefore, the potential of H' is
 
 $$\Phi(H') \le t(H) + x.degree + 2(m(H) - c + 2).$$
 

--- a/docs/Chap19/Problems/19-1.md
+++ b/docs/Chap19/Problems/19-1.md
@@ -24,11 +24,9 @@
 
 **b.** Line 7 takes actual time bounded by $x.degree$ since updating each of the children of $x$ only takes constant time. So, if $c$ is the number of cascading cuts that are done, the actual cost is $O(c + x.degree)$.
 
-**c.** From the cascading cut, we marked at most one more node, so, $m(H') \le 1 + m(H)$ regardless of the number of calls to cascading cut, because only the highest thing in the chain of calls actually goes from unmarked to marked.
+**c.** We examine the number of trees in the root list $t(H)$ and the number of marked nodes $m(H)$ of the resulting Fibonacci heap $H'$ to upper-bound its potential. The number of trees $t(H)$ increases by the number of children $x$ had ($=x.degree), due to line 7 of $\text{PISANO-DELETE(H, x)}$. The number of marked nodes in $H'$ is calculated as follows. The first $c - 1$ recursive calls out of the $c$ calls to $CASCADING-CUT$ unmarks a marked node (line 4 of $CUT$ invoked by line 5 of $CASCADING-CUT$). The final $c$th call to $CASCADING-CUT$ marks an unmarked node (line 4 of $CASCADING-CUT$), and therefore, the total change in marked nodes is $-(c - 1) + 1 = -c + 2$. Therefore, the potential of H' is
 
-Also, the number of children increases by the number of children that $x$ had, that is $t(H') = x.degree + t(H)$. Putting these together, we get that
-
-$$\Phi(H') \le t(H) + x.degree + 2(1 + m(H)).$$
+$$\Phi(H') \le t(H) + x.degree + 2(m(H) - c + 2).$$
 
 **d.** The asymptotic time is
 


### PR DESCRIPTION
The previous explanation seemed to overlook the fact that the first c-1 calls to CASCADING-CUT unmarks a marked node. Please check if my logic is correct.