### PR TITLE
Update 21-3.md

### DIFF
--- a/docs/Chap21/Problems/21-3.md
+++ b/docs/Chap21/Problems/21-3.md
@@ -26,7 +26,7 @@
 
 **a.** Suppose that we let $\le_{LCA}$ to be an ordering on the vertices so that $u \le_{LCA} v$ if we run line 7 of $\text{LCA}(u)$ before line 7 of $\text{LCA}(v)$. Then, when we are running line 7 of $\text{LCA}(u)$, we immediately go on to the **for** loop on line 8.
 
-So, while we are doing this **for** loop, we still haven't called line 7 of $\text{LCA}(v)$. This means that $v.color$ is white, and so, the pair $\\{u, v\\}$ is not considered during the run of $\text{LCA}(u)$. However, during the **for** loop of $\text{LCA}(v)$, since line 7 of $\text{LCA}(u)$ has already run, $u.color = black$. This means that we will consider the pair $\\{u, v\\}$ during the running of $\text{LCA}(v)$.
+So, while we are doing this **for** loop, we still haven't called line 7 of $\text{LCA}(v)$. This means that $v.color$ is white, and so, the pair $\\{u, v\\}$ is not considered during the run of $\text{LCA}(u)$. However, during the **for** loop of $\text{LCA}(v)$, since line 7 of $\text{LCA}(u)$ has already run, $u.color = black$. This means that we will consider the pair $\\{v, u\\}$ during the running of $\text{LCA}(v)$.
 
 It is not obvious what the ordering $\le_{LCA}$ is, as it will be implementation dependent. It depends on the order in which child vertices are iterated in the **for** loop on line 3. That is, it doesn't just depend on the graph structure.
 


### PR DESCRIPTION
Changing {u, v} to {v, u} because we will make that check during LCA(v) and we will be analysing the pair {v, u}. (we analyze the pair {u, v} earlier during LCA(u), but v is not black at this time so we won't print anything)