### PR TITLE
Update 22.2.md

### DIFF
--- a/docs/Chap22/22.2.md
+++ b/docs/Chap22/22.2.md
@@ -59,8 +59,8 @@ Let $G$ be the graph shown in the first picture, $G_\pi = (V, E_\pi)$ be the gra
 We could see that $E_\pi$ will never be produced by running BFS on $G$.
 
 <center>
-![](../img/22.2-6-1.png)
 ![](../img/22.2-6-2.png)
+![](../img/22.2-6-1.png)
 </center>
 
 - If $y$ precedes $v$ in the $Adj[s]$. We'll dequeue $y$ before $v$, so $u.\pi$ and $x.\pi$ are both $y$. However, this is not the case.


### PR DESCRIPTION
The two images order don't correspond to the text. 

The text says "Let G be the graph shown in the first picture, G_pi be the graph shown in the second picture". But the first picture is https://github.com/walkccc/CLRS/blob/master/docs/img/22.2-6-1.png which is G_pi.

Switching the order of the images