### PR TITLE
Update 24.1.md

### DIFF
--- a/docs/Chap24/24.1.md
+++ b/docs/Chap24/24.1.md
@@ -91,17 +91,16 @@ BELLMAN-FORD'(G, w, s)
     for each edge(u, v) ∈ G.E
         if v.d > u.d + w(u, v)
             mark v
-    for each vertex v ∈ marked vertices
-        FOLLOW-AND-MARK-PRED(v)
+    for each vertex u ∈ marked vertices
+        DFS-MARK(u)
 ```
 
 ```cpp
-FOLLOW-AND-MARK-PRED(v)
-    if v != NIL and v.d != -∞
-        v.d = -∞
-        FOLLOW-AND-MARK-PRED(v.π)
-    else
-        return
+DFS-MARK(u)
+    if u != NIL and u.d != -∞
+        u.d = -∞
+        for each v in G.Adj[u]
+            DFS-MARK(v)
 ```
 
 After running $\text{BELLMAN-FORD}'$, run $\text{DFS}$ with all vertices on negative-weight cycles as source vertices. All the vertices that can be reached from these vertices should have their $d$ attributes set to $-\infty$.


### PR DESCRIPTION
The current solution suggests to start from the marked vertices and go up the predecessor tree to mark all these nodes with -infinity.  But these nodes are not necessarily reachable from these mark nodes, i.e. the direction in which we traverse is wrong. We should simply run a DFS on the marked nodes to see all the ones that are reachable from them.