### PR TITLE
Update 15.4.md

### DIFF
--- a/docs/Chap15/15.4.md
+++ b/docs/Chap15/15.4.md
@@ -11,6 +11,7 @@ $\langle 1, 0, 0, 1, 1, 0 \rangle$ or $\langle 1, 0, 1, 0, 1, 0 \rangle$.
 ```cpp
 PRINT-LCS(c, X, Y, i, j)
     if c[i, j] == 0
+        print X[i]
         return
     if X[i] == Y[j]
         PRINT-LCS(c, X, Y, i - 1, j - 1)


### PR DESCRIPTION
One print statement was missing in the base case. If we skip that one, then it won't print the first character that was common in LCS.