### PR TITLE
Update 4.3.md 

### DIFF
--- a/docs/Chap04/4.3.md
+++ b/docs/Chap04/4.3.md
@@ -97,35 +97,35 @@ The recurrence is
 
 To show $\Theta$ bound, separately show $O$ and $\Omega$ bounds.
 
-- For $O(n\lg n)$, we guess $T(n) \le c(n - 2)\lg(n - 2)$,
+- For $O(n\lg n)$, we guess $T(n) \le c(n - 2)\lg(n - 2) - 2c$,
 
   $$
   \begin{aligned}
   T(n) & \le c(\lceil n / 2 \rceil -2 )\lg(\lceil n / 2 \rceil - 2) + c(\lfloor n / 2 \rfloor - 2)\lg(\lfloor n / 2 \rfloor - 2) + dn \\\\
-       & \le c(n / 2 + 1 -2 )\lg(n / 2 + 1 - 2) + c(n / 2 - 2)\lg(n / 2 - 2) + dn \\\\
+       & \le c(n / 2 + 1 -2 )\lg(n / 2 + 1 - 2) - 2c + c(n / 2 - 2)\lg(n / 2 - 2) - 2c + dn \\\\
        & \le c(n / 2 - 1 )\lg(n / 2 - 1) + c(n / 2 - 1)\lg(n / 2 - 1) + dn \\\\
-       & =   c\frac{n - 2}{2}\lg\frac{n - 2}{2} + c\frac{n - 2}{2}\lg\frac{n - 2}{2} + dn \\\\
-       & =   c(n - 2)\lg\frac{n - 2}{2} + dn \\\\
-       & =   c(n - 2)\lg(n - 2) - c(n - 2) + dn \\\\
-       & =   c(n - 2)\lg(n - 2) + (d - c)n + 2c \\\\
-       & \le c(n - 2)\lg(n - 2),
+       & =   c\frac{n - 2}{2}\lg\frac{n - 2}{2} + c\frac{n - 2}{2}\lg\frac{n - 2}{2} - 4c + dn \\\\
+       & =   c(n - 2)\lg\frac{n - 2}{2} - 4c + dn \\\\
+       & =   c(n - 2)\lg(n - 2) - c(n - 2) - 4c + dn \\\\
+       & =   c(n - 2)\lg(n - 2) + (d - c)n + 2c - 4c\\\\
+       & \le c(n - 2)\lg(n - 2) - 2c,
   \end{aligned}
   $$
 
   where the last step holds for $c > d$.
 
-- For $\Omega(n\lg n)$, we guess $T(n) \ge c(n + 2)\lg (n + 2)$,
+- For $\Omega(n\lg n)$, we guess $T(n) \ge c(n + 2)\lg (n + 2) + 2c$,
 
   $$
   \begin{aligned}
   T(n) & \ge c(\lceil n / 2 \rceil +2 )\lg(\lceil n / 2 \rceil + 2) + c(\lfloor n / 2 \rfloor + 2)\lg(\lfloor n / 2 \rfloor + 2) + dn \\\\
-       & \ge c(n / 2 + 2)\lg(n / 2 + 2) + c(n / 2-1+2)\lg(n / 2-1+2) + dn \\\\
-       & \ge c(n / 2 + 1 )\lg(n / 2 + 1) + c(n / 2 + 1)\lg(n / 2 + 1) + dn \\\\
-       & \ge c\frac{n + 2}{2}\lg\frac{n + 2}{2} + c\frac{n + 2}{2}\lg\frac{n + 2}{2} + dn \\\\
-       & =   c(n + 2)\lg\frac{n + 2}{2} + dn \\\\
-       & =   c(n + 2)\lg(n + 2) - c(n + 2) + dn \\\\
-       & =   c(n + 2)\lg(n + 2) + (d - c)n - 2c \\\\
-       & \ge c(n + 2)\lg(n + 2),
+       & \ge c(n / 2 + 2)\lg(n / 2 + 2) + 2c + c(n / 2-1+2)\lg(n / 2-1+2) + 2c + dn \\\\
+       & \ge c(n / 2 + 1 )\lg(n / 2 + 1) + c(n / 2 + 1)\lg(n / 2 + 1) + 4c + dn \\\\
+       & \ge c\frac{n + 2}{2}\lg\frac{n + 2}{2} + c\frac{n + 2}{2}\lg\frac{n + 2}{2} + 4c + dn \\\\
+       & =   c(n + 2)\lg\frac{n + 2}{2} + 4c + dn \\\\
+       & =   c(n + 2)\lg(n + 2) - c(n + 2) + 4c + dn \\\\
+       & =   c(n + 2)\lg(n + 2) + (d - c)n - 2c + 4c\\\\
+       & \ge c(n + 2)\lg(n + 2) + 2c,
   \end{aligned}
   $$
 

--- a/docs/Chap04/4.3.md
+++ b/docs/Chap04/4.3.md
@@ -102,12 +102,12 @@ To show $\Theta$ bound, separately show $O$ and $\Omega$ bounds.
   $$
   \begin{aligned}
   T(n) & \le c(\lceil n / 2 \rceil -2 )\lg(\lceil n / 2 \rceil - 2) + c(\lfloor n / 2 \rfloor - 2)\lg(\lfloor n / 2 \rfloor - 2) + dn \\\\
-       & \le c(n / 2 + 1 -2 )\lg(n / 2 + 1 - 2) - 2c + c(n / 2 - 2)\lg(n / 2 - 2) - 2c + dn \\\\
+       & \le c(n / 2 + 1 - 2)\lg(n / 2 + 1 - 2) - 2c + c(n / 2 - 2)\lg(n / 2 - 2) - 2c + dn \\\\
        & \le c(n / 2 - 1 )\lg(n / 2 - 1) + c(n / 2 - 1)\lg(n / 2 - 1) + dn \\\\
        & =   c\frac{n - 2}{2}\lg\frac{n - 2}{2} + c\frac{n - 2}{2}\lg\frac{n - 2}{2} - 4c + dn \\\\
        & =   c(n - 2)\lg\frac{n - 2}{2} - 4c + dn \\\\
        & =   c(n - 2)\lg(n - 2) - c(n - 2) - 4c + dn \\\\
-       & =   c(n - 2)\lg(n - 2) + (d - c)n + 2c - 4c\\\\
+       & =   c(n - 2)\lg(n - 2) + (d - c)n + 2c - 4c \\\\
        & \le c(n - 2)\lg(n - 2) - 2c,
   \end{aligned}
   $$
@@ -119,12 +119,12 @@ To show $\Theta$ bound, separately show $O$ and $\Omega$ bounds.
   $$
   \begin{aligned}
   T(n) & \ge c(\lceil n / 2 \rceil +2 )\lg(\lceil n / 2 \rceil + 2) + c(\lfloor n / 2 \rfloor + 2)\lg(\lfloor n / 2 \rfloor + 2) + dn \\\\
-       & \ge c(n / 2 + 2)\lg(n / 2 + 2) + 2c + c(n / 2-1+2)\lg(n / 2-1+2) + 2c + dn \\\\
-       & \ge c(n / 2 + 1 )\lg(n / 2 + 1) + c(n / 2 + 1)\lg(n / 2 + 1) + 4c + dn \\\\
+       & \ge c(n / 2 + 2)\lg(n / 2 + 2) + 2c + c(n / 2 - 1 + 2)\lg(n / 2 - 1 + 2) + 2c + dn \\\\
+       & \ge c(n / 2 + 1)\lg(n / 2 + 1) + c(n / 2 + 1)\lg(n / 2 + 1) + 4c + dn \\\\
        & \ge c\frac{n + 2}{2}\lg\frac{n + 2}{2} + c\frac{n + 2}{2}\lg\frac{n + 2}{2} + 4c + dn \\\\
        & =   c(n + 2)\lg\frac{n + 2}{2} + 4c + dn \\\\
        & =   c(n + 2)\lg(n + 2) - c(n + 2) + 4c + dn \\\\
-       & =   c(n + 2)\lg(n + 2) + (d - c)n - 2c + 4c\\\\
+       & =   c(n + 2)\lg(n + 2) + (d - c)n - 2c + 4c \\\\
        & \ge c(n + 2)\lg(n + 2) + 2c,
   \end{aligned}
   $$
@@ -190,7 +190,7 @@ T(n) &=   4T(n / 2) + n \\\\
 \end{aligned}
 $$
 
-We can't proceed any further from the inequality above to conclude $T(n) \le cn^2$. 
+We can't proceed any further from the inequality above to conclude $T(n) \le cn^2$.
 
 Alternatively, let us try the guess
 


### PR DESCRIPTION
(Avoiding pitfalls) I was reading solution to 4.3.5 when I came across this error. In the line prior to the end, when proving that T(n) is O(nlgn), 2c was omitted. but doing so would mean c < 0 which is not correct. In other words induction hypothesis doesn't hold for the proof to be correct. adding -2c to induction hypothesis resolves the issue. same thing Omega.