### PR TITLE
Fix typo in Question 13-3

### DIFF
--- a/docs/Chap13/Problems/13-3.md
+++ b/docs/Chap13/Problems/13-3.md
@@ -8,7 +8,7 @@
 >
 > **d.** Show that $\text{AVL-INSERT}$, run on an $n$-node AVL tree, takes $O(\lg n)$ time and performs $O(1)$ rotations.
 
-**a.** Let $T(h)$ denote the minimum size of an AVL tree of height $h$. Since it is height $h$, it must have the max of it's children's heights is equal to $h - 1$. Since we are trying to get as few notes total as possible, suppose that the other child has as small of a height as is allowed. Because of the restriction of AVL trees, we have that the smaller child must be at least one less than the larger one, so, we have that
+**a.** Let $T(h)$ denote the minimum size of an AVL tree of height $h$. Since it is height $h$, it must have the max of it's children's heights is equal to $h - 1$. Since we are trying to get as few nodes total as possible, suppose that the other child has as small of a height as is allowed. Because of the restriction of AVL trees, we have that the smaller child must be at least one less than the larger one, so, we have that
 
 $$T(h) \ge T(h - 1) + T(h - 2) + 1,$$
 


### PR DESCRIPTION
Closes https://github.com/walkccc/CLRS/issues/442

Fixed typo from `notes` to `nodes` in Tree problem