### PR TITLE
Fix pseudocode for problem 6-2

### DIFF
--- a/docs/Chap06/Problems/6-2.md
+++ b/docs/Chap06/Problems/6-2.md
@@ -50,8 +50,8 @@ d-ARY-MAX-HEAPIFY(A, i)
     largest = i
     for k = 1 to d
         if d-ARY-CHILD(k, i) ≤ A.heap-size and A[d-ARY-CHILD(k, i)] > A[i]
-            if A[d-ARY-CHILD(k, i)] > largest
-                largest = A[d-ARY-CHILD(k, i)]
+            if A[d-ARY-CHILD(k, i)] > A[largest]
+                largest = d-ARY-CHILD(k, i)
     if largest != i
         exchange A[i] with A[largest]
         d-ARY-MAX-HEAPIFY(A, largest)
@@ -64,7 +64,7 @@ d-ARY-MAX-HEAP-INSERT(A, key)
     A.heap-size = A.heap-size + 1
     A[A.heap-size] = key
     i = A.heap-size
-    while i > 1 and A[d-ARY-PARENT(i) < A[i]]
+    while i > 1 and A[d-ARY-PARENT(i)] < A[i]
         exchange A[i] with A[d-ARY-PARENT(i)]
         i = d-ARY-PARENT(i)
 ```

--- a/docs/Chap06/Problems/6-2.md
+++ b/docs/Chap06/Problems/6-2.md
@@ -76,7 +76,7 @@ d-ARY-INCREASE-KEY(A, i, key)
     if key < A[i]
         error "new key is smaller than current key"
     A[i] = key
-    while i > 1 and A[d-ARY-PARENT(i) < A[i]]
+    while i > 1 and A[d-ARY-PARENT(i)] < A[i]
         exchange A[i] with A[d-ARY-PARENT(i)]
         i = d-ARY-PARENT(i)
 ```


### PR DESCRIPTION
Changes:
1. Variable `largest` of `d-ARY-MAX-HEAPIFY` procedure is now treated as a heap element index inside for-loop rather than the element itself, like it does outside the loop.
2. Move misplaced square bracket in `d-ARY-MAX-HEAP-INSERT` and `d-ARY-INCREASE-KEY` procedures.