### PR TITLE
Update 13.1.md

### DIFF
--- a/docs/Chap13/13.1.md
+++ b/docs/Chap13/13.1.md
@@ -44,7 +44,7 @@ Yes, it is.
 
 > Suppose that we "absorb" every red node in a red-black tree into its black parent, so that the children of the red node become children of the black parent. (Ignore what happens to the keys.) What are the possible degrees of a black node after all its red children are absorbed? What can you say about the depths of the leaves of the resulting tree?
 
-The possible degrees are $0$ through $5$, based on whether or not the black node was a root and whether it had one or two red children, each with either one or two black children. The depths could shrink by at most a factor of $1 / 2$.
+The degree of a node in a rooted tree is the number of its children (see Section B.5.2). Given this definition, the possible degrees are $0$, $2$, $3$ and $4$, based on whether the black node had zero, one or two red children, each with either zero or two black children. The depths could shrink by at most a factor of $1 / 2$.
 
 ## 13.1-5
 


### PR DESCRIPTION
Current solution seems to use a different definition of degree where a degree of a node in a tree includes its parent. The book uses a definition of degree that does not include the parent. This was previously discussed [here](https://github.com/walkccc/CLRS/issues/322).