### PR TITLE
Update 10.4.md

### DIFF
--- a/docs/Chap10/10.4.md
+++ b/docs/Chap10/10.4.md
@@ -27,11 +27,13 @@
 
 ```cpp
 PRINT-BINARY-TREE(T)
-    x = T.root
-    if x != NIL
-        PRINT-BINARY-TREE(x.left)
-        print x.key
-        PRINT-BINARY-TREE(x.right)
+    PRINT-BINARY-TREE-AUX(T.root)
+
+PRINT-BINARY-TREE-AUX(node)
+    if node != NIL
+        PRINT-BINARY-TREE-AUX(node.left)
+        print node.key
+        PRINT-BINARY-TREE-AUX(node.right)
 ```
 
 ## 10.4-3

--- a/docs/Chap10/10.4.md
+++ b/docs/Chap10/10.4.md
@@ -29,11 +29,11 @@
 PRINT-BINARY-TREE(T)
     PRINT-BINARY-TREE-AUX(T.root)
 
-PRINT-BINARY-TREE-AUX(node)
+PRINT-BINARY-TREE-AUX(x)
     if node != NIL
-        PRINT-BINARY-TREE-AUX(node.left)
-        print node.key
-        PRINT-BINARY-TREE-AUX(node.right)
+        PRINT-BINARY-TREE-AUX(x.left)
+        print x.key
+        PRINT-BINARY-TREE-AUX(x.right)
 ```
 
 ## 10.4-3


### PR DESCRIPTION
The original solution seems to treat the argument as both a node and the complete tree, and the way its used is inconsistent with how a binary tree is defined in 10.4. This modification introduces a `PRINT-BINARY-TREE-AUX` following the same form of the original solution, except that the argument is explicitly a node and not a binary tree.

Complete new solution:

```cpp
PRINT-BINARY-TREE(T)
    PRINT-BINARY-TREE-AUX(T.root)

PRINT-BINARY-TREE-AUX(node)
    if node != NIL
        PRINT-BINARY-TREE-AUX(node.left)
        print node.key
        PRINT-BINARY-TREE-AUX(node.right)
```