### PR TITLE
Update 5-2.md

### DIFF
--- a/docs/Chap05/Problems/5-2.md
+++ b/docs/Chap05/Problems/5-2.md
@@ -28,13 +28,14 @@
 
 ```cpp
 RANDOM-SEARCH(x, A, n)
-    v = Ø
-    while |Ø| != n
+    v = Ø                     // a set (or bitmap, etc.) of visited indices
+    while |v| < n:
         i = RANDOM(1, n)
-        if A[i] = x
-            return i
-        else
-            v = v ∩ i
+        if i ∉ v:             // only use i if it hasn't been picked before
+            if A[i] = x:
+                return i
+            else:
+                v = v ∪ {i}
     return NIL
 ```
 


### PR DESCRIPTION
- Fixed error in question 5-2(a) by replacing the incorrect operation `v = v ∩ i` with the proper union operation `v = v ∪ {i}`.
- Added the condition `if i ∉ v` to avoid processing already-visited indices.

(From the issue #534)