### PR TITLE
Update 1-1.md

### DIFF
--- a/docs/Chap01/Problems/1-1.md
+++ b/docs/Chap01/Problems/1-1.md
@@ -3,7 +3,6 @@
 $$
 \begin{array}{cccccccc}
          & \text{1 second}  & \text{1 minute}    & \text{1 hour}       & \text{1 day}            & \text{1 month}          & \text{1 year}           & \text{1 century} \\\\
-\hline
 \lg n    & 2^{10^6}         & 2^{6 \times 10^7}  & 2^{3.6 \times 10^9} & 2^{8.64 \times 10^{10}} & 2^{2.59 \times 10^{12}} & 2^{3.15 \times 10^{13}} & 2^{3.15 \times 10^{15}} \\\\
 \sqrt n  & 10^{12}          & 3.6 \times 10^{15} & 1.3 \times 10^{19}  & 7.46 \times 10^{21}     & 6.72 \times 10^{24}     & 9.95 \times 10^{26}     & 9.95 \times 10^{30} \\\\
 n        & 10^6             & 6 \times 10^7      & 3.6 \times 10^9     & 8.64 \times 10^{10}     & 2.59 \times 10^{12}     & 3.15 \times 10^{13}     & 3.15 \times 10^{15} \\\\


### PR DESCRIPTION
The following error occurred in both Brave and Edge browsers when rendering the LaTeX table:

<img width="1387" height="662" alt="image" src="https://github.com/user-attachments/assets/a8bfbd2e-2f5d-4799-a9f6-66a606b03566" />


I removed the \hline line to resolve the issue. While this means the visual dividing line is no longer shown, the table remains clear and readable in its current form.