### PR TITLE
Update 17.2.md

### DIFF
--- a/docs/Chap17/17.2.md
+++ b/docs/Chap17/17.2.md
@@ -48,7 +48,7 @@ $$
 
 Since the amortized cost is $\$3$ per operation, $\sum\limits_{i = 1}^n \hat c_i = 3n$.
 
-We know from Exercise 17.1-3 that $\sum\limits_{i = 1}^n \hat c_i < 3n$.
+We know from Exercise 17.1-3 that $\sum\limits_{i = 1}^n c_i < 3n$.
 
 Then we have
 


### PR DESCRIPTION
17.2-2
Changed $\sum\limits_{i = 1}^n \hat c_i < 3n$ to $\sum\limits_{i = 1}^n c_i < 3n$. The hat notation was likely a typo in the original solution. The result from Problem 17.1-3 used here is c_i.